### PR TITLE
[feature/develop_ph1 -> develop_ph1]usersパッケージのテストコードの不具合修正

### DIFF
--- a/users/src/test/java/com/project/abydos/saki/api/users/controller/LoginControllerTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/controller/LoginControllerTest.java
@@ -12,12 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -41,14 +36,11 @@ class LoginControllerTest {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    private MockHttpServletRequest request;
-
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(loginController)
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
-        request = new MockHttpServletRequest();
     }
 
     @Test

--- a/users/src/test/java/com/project/abydos/saki/api/users/controller/LoginControllerTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/controller/LoginControllerTest.java
@@ -6,13 +6,21 @@ import com.project.abydos.saki.api.users.request.LoginRequest;
 import com.project.abydos.saki.api.users.response.LoginResponse;
 import com.project.abydos.saki.common.constant.Endpoint;
 import com.project.abydos.saki.api.users.constant.UsersEndpoint;
+import com.project.abydos.saki.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -20,18 +28,28 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
 class LoginControllerTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    @InjectMocks
+    private LoginController loginController;
 
-    @MockBean
+    @Mock
     private LoginFacade loginFacade;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(loginController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+        request = new MockHttpServletRequest();
+    }
 
     @Test
     void ログイン成功時にトークンとユーザー名が返却される() throws Exception {

--- a/users/src/test/java/com/project/abydos/saki/api/users/facade/LoginFacadeTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/facade/LoginFacadeTest.java
@@ -33,6 +33,6 @@ class LoginFacadeTest {
         LoginResponse result = loginFacade.login(request);
 
         assertThat(result.getToken()).isEqualTo("token");
-        assertThat(result.getUser_name()).isEqualTo("テストユーザー");
+        assertThat(result.getUserName()).isEqualTo("テストユーザー");
     }
 }

--- a/users/src/test/java/com/project/abydos/saki/api/users/service/LoginServiceTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/service/LoginServiceTest.java
@@ -59,7 +59,7 @@ class LoginServiceTest {
         LoginResponse response = loginService.login(request);
 
         assertThat(response.getToken()).isNotBlank();
-        assertThat(response.getUser_name()).isEqualTo("テストユーザー");
+        assertThat(response.getUserName()).isEqualTo("テストユーザー");
     }
 
     @Test


### PR DESCRIPTION
usersパッケージのログインAPIのテストコードが

- produtsのControllerクラスと同じ形式で実施する
- 変数名をキャメルケースに変更し、レスポンス返却時はSnakeStrategyでスネークケースに変えているため、テストコードのgetterを修正