### PR TITLE
[feature/develop_ph1 -> develop_ph1] 注文確定APIの実装

### DIFF
--- a/common/src/main/java/com/project/abydos/saki/common/constant/ProductStatus.java
+++ b/common/src/main/java/com/project/abydos/saki/common/constant/ProductStatus.java
@@ -18,6 +18,11 @@ public enum ProductStatus {
 
     private final String code;
 
+    /**
+     * 購入可能なステータスかどうかを判定する.
+     *
+     * @return 販売中の場合true
+     */
     public boolean isAvailable() {
         return this == ON_SALE;
     }

--- a/common/src/main/java/com/project/abydos/saki/common/constant/ProductStatus.java
+++ b/common/src/main/java/com/project/abydos/saki/common/constant/ProductStatus.java
@@ -1,0 +1,24 @@
+package com.project.abydos.saki.common.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 商品販売ステータス定義.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ProductStatus {
+    /** 販売中 */
+    ON_SALE("O"),
+    /** 売切 */
+    SOLD_OUT("S"),
+    /** 販売終了 */
+    DISCONTINUED("D");
+
+    private final String code;
+
+    public boolean isAvailable() {
+        return this == ON_SALE;
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/constant/OrderErrorLogMessage.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/constant/OrderErrorLogMessage.java
@@ -1,0 +1,25 @@
+package com.project.abydos.saki.api.orders.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 注文確定API固有のエラーログメッセージ定義.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorLogMessage {
+    /** 商品が存在しない */
+    PRODUCT_NOT_FOUND("Product not found: {}", "product_id=%s"),
+    /** 商品ステータスが購入不可 */
+    PRODUCT_UNAVAILABLE("Product unavailable: {}", "product_id=%s"),
+    /** 在庫不足 */
+    OUT_OF_STOCK("Out of stock: {}", "product_id=%s, stock=%s, quantity=%s");
+
+    private final String message;
+    private final String detailFormat;
+
+    public String formatDetail(Object... args) {
+        return String.format(detailFormat, args);
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/constant/OrderErrorLogMessage.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/constant/OrderErrorLogMessage.java
@@ -14,11 +14,19 @@ public enum OrderErrorLogMessage {
     /** 商品ステータスが購入不可 */
     PRODUCT_UNAVAILABLE("Product unavailable: {}", "product_id=%s"),
     /** 在庫不足 */
-    OUT_OF_STOCK("Out of stock: {}", "product_id=%s, stock=%s, quantity=%s");
+    OUT_OF_STOCK("Out of stock: {}", "product_id=%s, stock=%s, quantity=%s"),
+    /** トランザクション競合による在庫不足 */
+    STOCK_CONDITION_CONFLICT("Transaction canceled due to condition check failure: {}", "stock condition not met");
 
     private final String message;
     private final String detailFormat;
 
+    /**
+     * 詳細メッセージをフォーマットする.
+     *
+     * @param args フォーマット引数
+     * @return フォーマット済み詳細メッセージ
+     */
     public String formatDetail(Object... args) {
         return String.format(detailFormat, args);
     }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
@@ -5,12 +5,9 @@ import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.request.OrdersApiRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.common.constant.Endpoint;
-import com.project.abydos.saki.common.constant.ErrorCode;
-import com.project.abydos.saki.common.exception.ApiException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -41,11 +38,7 @@ public class OrdersController {
      * @return 成功時は200 OK
      */
     @PostMapping(Endpoint.ORDERS)
-    public ResponseEntity<Void> postOrders(@Valid @RequestBody OrderConfirmedRequest orderConfirmedRequest, BindingResult bindingResult) {
-
-        if (bindingResult.hasErrors()) {
-            throw new ApiException(ErrorCode.API_ERR001);
-        }
+    public ResponseEntity<Void> postOrders(@Valid @RequestBody OrderConfirmedRequest orderConfirmedRequest) {
 
         ordersFacade.confirmed(orderConfirmedRequest);
 

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
@@ -1,6 +1,7 @@
 package com.project.abydos.saki.api.orders.controller;
 
 import com.project.abydos.saki.api.orders.facade.OrdersFacade;
+import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.request.OrdersApiRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.common.constant.Endpoint;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +32,14 @@ public class OrdersController {
     @GetMapping(Endpoint.ORDERS)
     public ResponseEntity<OrdersApiResponse> getOrders(@Valid OrdersApiRequest ordersApiRequest) {
         return ResponseEntity.ok(ordersFacade.getOrders(ordersApiRequest));
+    }
+
+    @PostMapping(Endpoint.ORDERS)
+    public ResponseEntity<Void> postOrders(@Valid OrderConfirmedRequest orderConfirmedRequest) {
+
+        ordersFacade.confirmed(orderConfirmedRequest);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
@@ -5,13 +5,13 @@ import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.request.OrdersApiRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.common.constant.Endpoint;
+import com.project.abydos.saki.common.constant.ErrorCode;
+import com.project.abydos.saki.common.exception.ApiException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 注文履歴一覧API コントローラー.
@@ -34,8 +34,18 @@ public class OrdersController {
         return ResponseEntity.ok(ordersFacade.getOrders(ordersApiRequest));
     }
 
+    /**
+     * 注文を確定する.
+     *
+     * @param orderConfirmedRequest 注文確定リクエスト
+     * @return 成功時は200 OK
+     */
     @PostMapping(Endpoint.ORDERS)
-    public ResponseEntity<Void> postOrders(@Valid OrderConfirmedRequest orderConfirmedRequest) {
+    public ResponseEntity<Void> postOrders(@Valid @RequestBody OrderConfirmedRequest orderConfirmedRequest, BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            throw new ApiException(ErrorCode.API_ERR001);
+        }
 
         ordersFacade.confirmed(orderConfirmedRequest);
 

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderErrorCode.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderErrorCode.java
@@ -1,0 +1,22 @@
+package com.project.abydos.saki.api.orders.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 注文確定API固有のエラーコード定義.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode {
+    /** 商品が存在しない */
+    API_ORDER_ERR001(HttpStatus.BAD_REQUEST, "product not found."),
+    /** 商品ステータスが購入不可 */
+    API_ORDER_ERR002(HttpStatus.BAD_REQUEST, "product unavailable."),
+    /** 在庫不足 */
+    API_ORDER_ERR003(HttpStatus.BAD_REQUEST, "out of stock.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderException.java
@@ -12,12 +12,23 @@ public class OrderException extends RuntimeException {
     private final OrderErrorCode errorCode;
     private final String detail;
 
+    /**
+     * コンストラクタ.
+     *
+     * @param errorCode エラーコード
+     * @param detail エラー詳細情報
+     */
     public OrderException(@NonNull OrderErrorCode errorCode, String detail) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.detail = detail;
     }
 
+    /**
+     * HTTPステータスコードを取得する.
+     *
+     * @return HTTPステータス
+     */
     public HttpStatus getHttpStatus() {
         return errorCode.getHttpStatus();
     }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderException.java
@@ -1,0 +1,24 @@
+package com.project.abydos.saki.api.orders.exception;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 注文確定API固有のビジネス例外.
+ */
+@Getter
+public class OrderException extends RuntimeException {
+    private final OrderErrorCode errorCode;
+    private final String detail;
+
+    public OrderException(@NonNull OrderErrorCode errorCode, String detail) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderExceptionHandler.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderExceptionHandler.java
@@ -14,6 +14,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(basePackages = "com.project.abydos.saki.api.orders")
 public class OrderExceptionHandler {
 
+    /**
+     * 商品が存在しない場合の例外をハンドリングする.
+     *
+     * @param ex 商品未存在例外
+     * @return エラーレスポンス
+     */
     @ExceptionHandler(ProductNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleProductNotFoundException(ProductNotFoundException ex) {
         OrderErrorCode code = ex.getErrorCode();
@@ -24,6 +30,12 @@ public class OrderExceptionHandler {
         );
     }
 
+    /**
+     * 商品ステータスが購入不可の場合の例外をハンドリングする.
+     *
+     * @param ex 商品購入不可例外
+     * @return エラーレスポンス
+     */
     @ExceptionHandler(ProductUnavailableException.class)
     public ResponseEntity<ErrorResponse> handleProductUnavailableException(ProductUnavailableException ex) {
         OrderErrorCode code = ex.getErrorCode();
@@ -34,6 +46,12 @@ public class OrderExceptionHandler {
         );
     }
 
+    /**
+     * 在庫不足の場合の例外をハンドリングする.
+     *
+     * @param ex 在庫不足例外
+     * @return エラーレスポンス
+     */
     @ExceptionHandler(OutOfStockException.class)
     public ResponseEntity<ErrorResponse> handleOutOfStockException(OutOfStockException ex) {
         OrderErrorCode code = ex.getErrorCode();
@@ -43,4 +61,6 @@ public class OrderExceptionHandler {
                 code.getHttpStatus()
         );
     }
+
+
 }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderExceptionHandler.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OrderExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.project.abydos.saki.api.orders.exception;
+
+import com.project.abydos.saki.api.orders.constant.OrderErrorLogMessage;
+import com.project.abydos.saki.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 注文確定API固有の例外ハンドラー.
+ */
+@Slf4j
+@RestControllerAdvice(basePackages = "com.project.abydos.saki.api.orders")
+public class OrderExceptionHandler {
+
+    @ExceptionHandler(ProductNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleProductNotFoundException(ProductNotFoundException ex) {
+        OrderErrorCode code = ex.getErrorCode();
+        log.warn(OrderErrorLogMessage.PRODUCT_NOT_FOUND.getMessage(), ex.getDetail(), ex);
+        return new ResponseEntity<>(
+                new ErrorResponse(code.name(), code.getMessage()),
+                code.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(ProductUnavailableException.class)
+    public ResponseEntity<ErrorResponse> handleProductUnavailableException(ProductUnavailableException ex) {
+        OrderErrorCode code = ex.getErrorCode();
+        log.warn(OrderErrorLogMessage.PRODUCT_UNAVAILABLE.getMessage(), ex.getDetail(), ex);
+        return new ResponseEntity<>(
+                new ErrorResponse(code.name(), code.getMessage()),
+                code.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(OutOfStockException.class)
+    public ResponseEntity<ErrorResponse> handleOutOfStockException(OutOfStockException ex) {
+        OrderErrorCode code = ex.getErrorCode();
+        log.warn(OrderErrorLogMessage.OUT_OF_STOCK.getMessage(), ex.getDetail(), ex);
+        return new ResponseEntity<>(
+                new ErrorResponse(code.name(), code.getMessage()),
+                code.getHttpStatus()
+        );
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OutOfStockException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OutOfStockException.java
@@ -5,6 +5,11 @@ package com.project.abydos.saki.api.orders.exception;
  */
 public class OutOfStockException extends OrderException {
 
+    /**
+     * コンストラクタ.
+     *
+     * @param detail エラー詳細情報
+     */
     public OutOfStockException(String detail) {
         super(OrderErrorCode.API_ORDER_ERR003, detail);
     }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OutOfStockException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/OutOfStockException.java
@@ -1,0 +1,11 @@
+package com.project.abydos.saki.api.orders.exception;
+
+/**
+ * 在庫不足の場合の例外.
+ */
+public class OutOfStockException extends OrderException {
+
+    public OutOfStockException(String detail) {
+        super(OrderErrorCode.API_ORDER_ERR003, detail);
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductNotFoundException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductNotFoundException.java
@@ -1,0 +1,11 @@
+package com.project.abydos.saki.api.orders.exception;
+
+/**
+ * 商品が存在しない場合の例外.
+ */
+public class ProductNotFoundException extends OrderException {
+
+    public ProductNotFoundException(String detail) {
+        super(OrderErrorCode.API_ORDER_ERR001, detail);
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductNotFoundException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductNotFoundException.java
@@ -5,6 +5,11 @@ package com.project.abydos.saki.api.orders.exception;
  */
 public class ProductNotFoundException extends OrderException {
 
+    /**
+     * コンストラクタ.
+     *
+     * @param detail エラー詳細情報
+     */
     public ProductNotFoundException(String detail) {
         super(OrderErrorCode.API_ORDER_ERR001, detail);
     }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductUnavailableException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductUnavailableException.java
@@ -5,6 +5,11 @@ package com.project.abydos.saki.api.orders.exception;
  */
 public class ProductUnavailableException extends OrderException {
 
+    /**
+     * コンストラクタ.
+     *
+     * @param detail エラー詳細情報
+     */
     public ProductUnavailableException(String detail) {
         super(OrderErrorCode.API_ORDER_ERR002, detail);
     }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductUnavailableException.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/exception/ProductUnavailableException.java
@@ -1,0 +1,11 @@
+package com.project.abydos.saki.api.orders.exception;
+
+/**
+ * 商品ステータスが購入不可の場合の例外.
+ */
+public class ProductUnavailableException extends OrderException {
+
+    public ProductUnavailableException(String detail) {
+        super(OrderErrorCode.API_ORDER_ERR002, detail);
+    }
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/facade/OrdersFacade.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/facade/OrdersFacade.java
@@ -1,5 +1,6 @@
 package com.project.abydos.saki.api.orders.facade;
 
+import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.request.OrdersApiRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.api.orders.service.OrdersService;
@@ -28,6 +29,11 @@ public class OrdersFacade {
         Long seqUserId = SecurityUtils.getCurrentUserId();
 
         return ordersService.getOrders(seqUserId, ordersApiRequest.getLimit(), ordersApiRequest.getLastOrderId());
+    }
+
+    public void confirmed(@NonNull OrderConfirmedRequest orderConfirmedRequest) {
+        Long seqUserId = SecurityUtils.getCurrentUserId();
+        ordersService.confirmed(seqUserId, orderConfirmedRequest.getProducts());
     }
 
 }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/facade/OrdersFacade.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/facade/OrdersFacade.java
@@ -31,6 +31,11 @@ public class OrdersFacade {
         return ordersService.getOrders(seqUserId, ordersApiRequest.getLimit(), ordersApiRequest.getLastOrderId());
     }
 
+    /**
+     * 注文確定処理を実行する.
+     *
+     * @param orderConfirmedRequest 注文確定リクエスト
+     */
     public void confirmed(@NonNull OrderConfirmedRequest orderConfirmedRequest) {
         Long seqUserId = SecurityUtils.getCurrentUserId();
         ordersService.confirmed(seqUserId, orderConfirmedRequest.getProducts());

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/request/OrderConfirmedRequest.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/request/OrderConfirmedRequest.java
@@ -1,0 +1,34 @@
+package com.project.abydos.saki.api.orders.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 注文確定APIのリクエストクラス
+ */
+@Data
+public class OrderConfirmedRequest {
+
+    /** 商品リスト */
+    @Size(min = 1)
+    private List<Product> products;
+
+    /**
+     * 注文商品
+     */
+    @Data
+    public static class Product {
+
+        /** 商品Id */
+        private Long product_id;
+
+        /** 注文数量 */
+        @Min(1)
+        private Long quantity;
+
+    }
+
+}

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/request/OrderConfirmedRequest.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/request/OrderConfirmedRequest.java
@@ -1,8 +1,13 @@
 package com.project.abydos.saki.api.orders.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
@@ -10,23 +15,31 @@ import java.util.List;
  * 注文確定APIのリクエストクラス
  */
 @Data
+@AllArgsConstructor
+@RequiredArgsConstructor
 public class OrderConfirmedRequest {
 
     /** 商品リスト */
-    @Size(min = 1)
+    @Valid
+    @Size(min = 1, max = 100)
+    @NotEmpty
     private List<Product> products;
 
     /**
      * 注文商品
      */
     @Data
+    @AllArgsConstructor
+    @RequiredArgsConstructor
     public static class Product {
 
         /** 商品Id */
+        @NotNull
         private Long product_id;
 
         /** 注文数量 */
         @Min(1)
+        @NotNull
         private Long quantity;
 
     }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/service/OrdersService.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/service/OrdersService.java
@@ -12,9 +12,11 @@ import com.project.abydos.saki.dynamodb.entity.Order;
 import com.project.abydos.saki.dynamodb.entity.OrderDetail;
 import com.project.abydos.saki.dynamodb.entity.Product;
 import com.project.abydos.saki.dynamodb.repository.*;
+import com.project.abydos.saki.dynamodb.exception.StockConditionException;
 import com.project.abydos.saki.dynamodb.param.OrderTransactionParam;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import org.springframework.util.CollectionUtils;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 /**
  * 注文履歴一覧API サービス.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrdersService {
@@ -132,14 +135,19 @@ public class OrdersService {
      * @param seqUserId ユーザーID
      * @param purchaseProducts 注文商品リスト
      */
-    public void confirmed(Long seqUserId, List<OrderConfirmedRequest.Product> purchaseProducts) {
+    public void confirmed(@NonNull Long seqUserId, List<OrderConfirmedRequest.Product> purchaseProducts) {
 
-        // 3.1 productsテーブルからBatchGetItemで取得
-        List<Long> productIds = purchaseProducts.stream()
-                .map(OrderConfirmedRequest.Product::getProduct_id).toList();
+        // 3.1 同一商品の数量を集約
+        Map<Long, Long> aggregatedQuantities = purchaseProducts.stream()
+                .collect(Collectors.groupingBy(
+                        OrderConfirmedRequest.Product::getProduct_id,
+                        Collectors.summingLong(OrderConfirmedRequest.Product::getQuantity)));
+
+        // 3.2 productsテーブルから集約後のproduct_idをキーにしてBatchGetItemで取得
+        List<Long> productIds = new ArrayList<>(aggregatedQuantities.keySet());
         List<Product> products = productRepository.findByIds(productIds);
 
-        // 3.2 商品が存在しない場合
+        // 3.3 商品が存在しない場合
         if (products.size() != productIds.size()) {
             Set<Long> foundIds = products.stream().map(Product::getProductId).collect(Collectors.toSet());
             List<Long> missingIds = productIds.stream().filter(id -> !foundIds.contains(id)).toList();
@@ -149,27 +157,21 @@ public class OrdersService {
         Map<Long, Product> productMap = products.stream()
                 .collect(Collectors.toMap(Product::getProductId, p -> p));
 
-        for (OrderConfirmedRequest.Product req : purchaseProducts) {
-            Product product = productMap.get(req.getProduct_id());
+        for (Map.Entry<Long, Long> entry : aggregatedQuantities.entrySet()) {
+            Product product = productMap.get(entry.getKey());
 
-            // 3.3 商品ステータスが購入不可
+            // 3.4 商品ステータスが購入不可
             if (!ProductStatus.ON_SALE.getCode().equals(product.getStatus())) {
                 throw new ProductUnavailableException(OrderErrorLogMessage.PRODUCT_UNAVAILABLE.formatDetail(product.getProductId()));
             }
 
-            // 3.4 在庫数 < 注文数量
-            if (product.getStock() < req.getQuantity()) {
-                throw new OutOfStockException(OrderErrorLogMessage.OUT_OF_STOCK.formatDetail(product.getProductId(), product.getStock(), req.getQuantity()));
+            // 3.5 在庫数 < 集約後の注文数量
+            if (product.getStock() < entry.getValue()) {
+                throw new OutOfStockException(OrderErrorLogMessage.OUT_OF_STOCK.formatDetail(product.getProductId(), product.getStock(), entry.getValue()));
             }
         }
 
         // 4. 注文履歴テーブルの登録（TransactWriteItems）
-
-        // 同一商品の数量を集約
-        Map<Long, Long> aggregatedQuantities = purchaseProducts.stream()
-                .collect(Collectors.groupingBy(
-                        OrderConfirmedRequest.Product::getProduct_id,
-                        Collectors.summingLong(OrderConfirmedRequest.Product::getQuantity)));
 
         // 4.1 order_id採番
         Long orderId = sequenceRepository.getNextValue("order_id", 1L);
@@ -202,6 +204,10 @@ public class OrdersService {
                 .details(detailParams)
                 .build();
 
-        orderRepository.saveOrder(param);
+        try {
+            orderRepository.saveOrder(param);
+        } catch (StockConditionException ex) {
+            throw new OutOfStockException(OrderErrorLogMessage.STOCK_CONDITION_CONFLICT.getDetailFormat());
+        }
     }
 }

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/service/OrdersService.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/service/OrdersService.java
@@ -1,12 +1,18 @@
 package com.project.abydos.saki.api.orders.service;
 
+import com.project.abydos.saki.api.orders.constant.OrderErrorLogMessage;
+import com.project.abydos.saki.api.orders.exception.OutOfStockException;
+import com.project.abydos.saki.api.orders.exception.ProductNotFoundException;
+import com.project.abydos.saki.api.orders.exception.ProductUnavailableException;
+import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.api.orders.constant.DeliveryStatus;
+import com.project.abydos.saki.common.constant.ProductStatus;
 import com.project.abydos.saki.dynamodb.entity.Order;
 import com.project.abydos.saki.dynamodb.entity.OrderDetail;
-import com.project.abydos.saki.dynamodb.repository.OrderRepository;
-import com.project.abydos.saki.dynamodb.repository.PagedResult;
-import com.project.abydos.saki.dynamodb.repository.OrderDetailRepository;
+import com.project.abydos.saki.dynamodb.entity.Product;
+import com.project.abydos.saki.dynamodb.repository.*;
+import com.project.abydos.saki.dynamodb.param.OrderTransactionParam;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +31,8 @@ public class OrdersService {
 
     private final OrderRepository orderRepository;
     private final OrderDetailRepository orderDetailRepository;
+    private final ProductRepository productRepository;
+    private final SequenceRepository sequenceRepository;
 
     /**
      * 注文履歴一覧を取得する.
@@ -115,5 +123,85 @@ public class OrdersService {
                 .orderNum(detail.getOrderNum())
                 .total(detail.getPrice() * detail.getOrderNum())
                 .build();
+    }
+
+    /**
+     * 注文確定処理.
+     * リクエストの注文可否チェックを実施し、TransactWriteItemsで注文を登録する.
+     *
+     * @param seqUserId ユーザーID
+     * @param purchaseProducts 注文商品リスト
+     */
+    public void confirmed(Long seqUserId, List<OrderConfirmedRequest.Product> purchaseProducts) {
+
+        // 3.1 productsテーブルからBatchGetItemで取得
+        List<Long> productIds = purchaseProducts.stream()
+                .map(OrderConfirmedRequest.Product::getProduct_id).toList();
+        List<Product> products = productRepository.findByIds(productIds);
+
+        // 3.2 商品が存在しない場合
+        if (products.size() != productIds.size()) {
+            Set<Long> foundIds = products.stream().map(Product::getProductId).collect(Collectors.toSet());
+            List<Long> missingIds = productIds.stream().filter(id -> !foundIds.contains(id)).toList();
+            throw new ProductNotFoundException(OrderErrorLogMessage.PRODUCT_NOT_FOUND.formatDetail(missingIds));
+        }
+
+        Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getProductId, p -> p));
+
+        for (OrderConfirmedRequest.Product req : purchaseProducts) {
+            Product product = productMap.get(req.getProduct_id());
+
+            // 3.3 商品ステータスが購入不可
+            if (!ProductStatus.ON_SALE.getCode().equals(product.getStatus())) {
+                throw new ProductUnavailableException(OrderErrorLogMessage.PRODUCT_UNAVAILABLE.formatDetail(product.getProductId()));
+            }
+
+            // 3.4 在庫数 < 注文数量
+            if (product.getStock() < req.getQuantity()) {
+                throw new OutOfStockException(OrderErrorLogMessage.OUT_OF_STOCK.formatDetail(product.getProductId(), product.getStock(), req.getQuantity()));
+            }
+        }
+
+        // 4. 注文履歴テーブルの登録（TransactWriteItems）
+
+        // 同一商品の数量を集約
+        Map<Long, Long> aggregatedQuantities = purchaseProducts.stream()
+                .collect(Collectors.groupingBy(
+                        OrderConfirmedRequest.Product::getProduct_id,
+                        Collectors.summingLong(OrderConfirmedRequest.Product::getQuantity)));
+
+        // 4.1 order_id採番
+        Long orderId = sequenceRepository.getNextValue("order_id", 1L);
+
+        // 4.2 detail_id採番（件数分まとめてインクリメント）
+        int detailCount = aggregatedQuantities.size();
+        Long lastDetailId = sequenceRepository.getNextValue("detail_id", (long) detailCount);
+        Long firstDetailId = lastDetailId - detailCount + 1;
+
+        // 明細パラメータ構築
+        List<OrderTransactionParam.DetailParam> detailParams = aggregatedQuantities.entrySet().stream()
+                .map(entry -> {
+                    Product product = productMap.get(entry.getKey());
+                    return OrderTransactionParam.DetailParam.builder()
+                            .productId(entry.getKey())
+                            .productName(product.getProductName())
+                            .shopId(product.getShopId())
+                            .price(product.getPrice())
+                            .quantity(entry.getValue())
+                            .build();
+                }).toList();
+
+        // トランザクション実行
+        OrderTransactionParam param = OrderTransactionParam.builder()
+                .userId(seqUserId)
+                .orderId(orderId)
+                .firstDetailId(firstDetailId)
+                .createdAt(System.currentTimeMillis())
+                .initialDeliveryStatus(DeliveryStatus.PROCESSING.getCode())
+                .details(detailParams)
+                .build();
+
+        orderRepository.saveOrder(param);
     }
 }

--- a/orders/src/test/java/com/project/abydos/saki/api/orders/controller/OrdersControllerTest.java
+++ b/orders/src/test/java/com/project/abydos/saki/api/orders/controller/OrdersControllerTest.java
@@ -17,10 +17,15 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
+import org.springframework.http.MediaType;
 
 @ExtendWith(SpringExtension.class)
 class OrdersControllerTest {
@@ -177,5 +182,111 @@ class OrdersControllerTest {
                         .param("lastOrderId", "1001"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.orders").isEmpty());
+    }
+
+    @Test
+    void 注文確定_正常系() throws Exception {
+        doNothing().when(ordersFacade).confirmed(any(OrderConfirmedRequest.class));
+
+        OrderConfirmedRequest request = new OrderConfirmedRequest();
+        OrderConfirmedRequest.Product product = new OrderConfirmedRequest.Product();
+        product.setProduct_id(1L);
+        product.setQuantity(2L);
+        request.setProducts(List.of(product));
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(ordersFacade).confirmed(any(OrderConfirmedRequest.class));
+    }
+
+    @Test
+    void 注文確定_商品リストが空の場合バリデーションエラー() throws Exception {
+        OrderConfirmedRequest request = new OrderConfirmedRequest();
+        request.setProducts(Collections.emptyList());
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 注文確定_数量が0の場合バリデーションエラー() throws Exception {
+        OrderConfirmedRequest request = new OrderConfirmedRequest();
+        OrderConfirmedRequest.Product product = new OrderConfirmedRequest.Product();
+        product.setProduct_id(1L);
+        product.setQuantity(0L);
+        request.setProducts(List.of(product));
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 注文確定_数量が負数の場合バリデーションエラー() throws Exception {
+        OrderConfirmedRequest request = new OrderConfirmedRequest();
+        OrderConfirmedRequest.Product product = new OrderConfirmedRequest.Product();
+        product.setProduct_id(1L);
+        product.setQuantity(-1L);
+        request.setProducts(List.of(product));
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 注文確定_productsがnullの場合バリデーションエラー() throws Exception {
+        String json = "{}";
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 注文確定_product_idがnullの場合バリデーションエラー() throws Exception {
+        String json = "{\"products\":[{\"quantity\":2}]}";
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 注文確定_quantityがnullの場合バリデーションエラー() throws Exception {
+        String json = "{\"products\":[{\"product_id\":1}]}";
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 注文確定_商品リストが101件の場合バリデーションエラー() throws Exception {
+        List<OrderConfirmedRequest.Product> products = java.util.stream.IntStream.rangeClosed(1, 101)
+                .mapToObj(i -> {
+                    OrderConfirmedRequest.Product p = new OrderConfirmedRequest.Product();
+                    p.setProduct_id((long) i);
+                    p.setQuantity(1L);
+                    return p;
+                }).toList();
+
+        OrderConfirmedRequest request = new OrderConfirmedRequest();
+        request.setProducts(products);
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/orders/src/test/java/com/project/abydos/saki/api/orders/facade/OrdersFacadeTest.java
+++ b/orders/src/test/java/com/project/abydos/saki/api/orders/facade/OrdersFacadeTest.java
@@ -1,5 +1,6 @@
 package com.project.abydos.saki.api.orders.facade;
 
+import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.request.OrdersApiRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.api.orders.service.OrdersService;
@@ -12,10 +13,10 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class OrdersFacadeTest {
@@ -64,6 +65,25 @@ class OrdersFacadeTest {
             OrdersApiResponse response = ordersFacade.getOrders(request);
 
             assertThat(response.getLastOrderId()).isEqualTo(100L);
+        }
+    }
+
+    @Test
+    void 注文確定_JWTから取得したuserIdでServiceのconfirmedが呼び出される() {
+        try (MockedStatic<SecurityUtils> mocked = mockStatic(SecurityUtils.class)) {
+            mocked.when(SecurityUtils::getCurrentUserId).thenReturn(1L);
+
+            OrderConfirmedRequest request = new OrderConfirmedRequest();
+            OrderConfirmedRequest.Product product = new OrderConfirmedRequest.Product();
+            product.setProduct_id(10L);
+            product.setQuantity(2L);
+            request.setProducts(List.of(product));
+
+            doNothing().when(ordersService).confirmed(1L, request.getProducts());
+
+            ordersFacade.confirmed(request);
+
+            verify(ordersService).confirmed(1L, request.getProducts());
         }
     }
 }

--- a/orders/src/test/java/com/project/abydos/saki/api/orders/service/OrdersServiceTest.java
+++ b/orders/src/test/java/com/project/abydos/saki/api/orders/service/OrdersServiceTest.java
@@ -1,12 +1,21 @@
 package com.project.abydos.saki.api.orders.service;
 
 import com.project.abydos.saki.api.orders.constant.DeliveryStatus;
+import com.project.abydos.saki.api.orders.exception.OutOfStockException;
+import com.project.abydos.saki.api.orders.exception.ProductNotFoundException;
+import com.project.abydos.saki.api.orders.exception.ProductUnavailableException;
+import com.project.abydos.saki.api.orders.request.OrderConfirmedRequest;
 import com.project.abydos.saki.api.orders.response.OrdersApiResponse;
 import com.project.abydos.saki.dynamodb.entity.Order;
 import com.project.abydos.saki.dynamodb.entity.OrderDetail;
+import com.project.abydos.saki.dynamodb.entity.Product;
+import com.project.abydos.saki.dynamodb.exception.StockConditionException;
 import com.project.abydos.saki.dynamodb.repository.OrderRepository;
 import com.project.abydos.saki.dynamodb.repository.PagedResult;
 import com.project.abydos.saki.dynamodb.repository.OrderDetailRepository;
+import com.project.abydos.saki.dynamodb.repository.ProductRepository;
+import com.project.abydos.saki.dynamodb.repository.SequenceRepository;
+import com.project.abydos.saki.dynamodb.param.OrderTransactionParam;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,7 +25,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +38,12 @@ class OrdersServiceTest {
 
     @Mock
     private OrderDetailRepository orderDetailRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private SequenceRepository sequenceRepository;
 
     @InjectMocks
     private OrdersService ordersService;
@@ -155,5 +172,149 @@ class OrdersServiceTest {
         detail.setOrderNum(orderNum);
         detail.setDeliveryStatus(deliveryStatus);
         return detail;
+    }
+
+    @Test
+    void 注文確定_正常系() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 10L, "O");
+        when(productRepository.findByIds(List.of(1L))).thenReturn(List.of(product));
+        when(sequenceRepository.getNextValue(eq("order_id"), eq(1L))).thenReturn(100L);
+        when(sequenceRepository.getNextValue(eq("detail_id"), eq(1L))).thenReturn(200L);
+        doNothing().when(orderRepository).saveOrder(any(OrderTransactionParam.class));
+
+        List<OrderConfirmedRequest.Product> products = List.of(createRequestProduct(1L, 2L));
+
+        ordersService.confirmed(1L, products);
+
+        verify(orderRepository).saveOrder(any(OrderTransactionParam.class));
+    }
+
+    @Test
+    void 注文確定_商品が存在しない場合にProductNotFoundExceptionがスローされる() {
+        when(productRepository.findByIds(List.of(1L, 2L))).thenReturn(List.of(
+                createProduct(1L, "商品A", 10001L, 1000L, 10L, "O")
+        ));
+
+        List<OrderConfirmedRequest.Product> products = List.of(
+                createRequestProduct(1L, 1L),
+                createRequestProduct(2L, 1L)
+        );
+
+        assertThatThrownBy(() -> ordersService.confirmed(1L, products))
+                .isInstanceOf(ProductNotFoundException.class);
+    }
+
+    @Test
+    void 注文確定_商品ステータスが購入不可の場合にProductUnavailableExceptionがスローされる() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 10L, "S");
+        when(productRepository.findByIds(List.of(1L))).thenReturn(List.of(product));
+
+        List<OrderConfirmedRequest.Product> products = List.of(createRequestProduct(1L, 1L));
+
+        assertThatThrownBy(() -> ordersService.confirmed(1L, products))
+                .isInstanceOf(ProductUnavailableException.class);
+    }
+
+    @Test
+    void 注文確定_在庫不足の場合にOutOfStockExceptionがスローされる() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 2L, "O");
+        when(productRepository.findByIds(List.of(1L))).thenReturn(List.of(product));
+
+        List<OrderConfirmedRequest.Product> products = List.of(createRequestProduct(1L, 5L));
+
+        assertThatThrownBy(() -> ordersService.confirmed(1L, products))
+                .isInstanceOf(OutOfStockException.class);
+    }
+
+    @Test
+    void 注文確定_商品ステータスが販売終了の場合にProductUnavailableExceptionがスローされる() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 10L, "D");
+        when(productRepository.findByIds(any())).thenReturn(List.of(product));
+
+        List<OrderConfirmedRequest.Product> products = List.of(createRequestProduct(1L, 1L));
+
+        assertThatThrownBy(() -> ordersService.confirmed(1L, products))
+                .isInstanceOf(ProductUnavailableException.class);
+    }
+
+    @Test
+    void 注文確定_在庫数と注文数量が同数の場合に正常終了する() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 5L, "O");
+        when(productRepository.findByIds(any())).thenReturn(List.of(product));
+        when(sequenceRepository.getNextValue(eq("order_id"), eq(1L))).thenReturn(100L);
+        when(sequenceRepository.getNextValue(eq("detail_id"), eq(1L))).thenReturn(200L);
+        doNothing().when(orderRepository).saveOrder(any(OrderTransactionParam.class));
+
+        List<OrderConfirmedRequest.Product> products = List.of(createRequestProduct(1L, 5L));
+
+        ordersService.confirmed(1L, products);
+
+        verify(orderRepository).saveOrder(any(OrderTransactionParam.class));
+    }
+
+    @Test
+    void 注文確定_同一商品が複数行ある場合に集約後の合計数量で在庫チェックされる() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 5L, "O");
+        when(productRepository.findByIds(any())).thenReturn(List.of(product));
+
+        // 個別では在庫内（3 < 5）だが、合計すると在庫超過（3+3=6 > 5）
+        List<OrderConfirmedRequest.Product> products = List.of(
+                createRequestProduct(1L, 3L),
+                createRequestProduct(1L, 3L)
+        );
+
+        assertThatThrownBy(() -> ordersService.confirmed(1L, products))
+                .isInstanceOf(OutOfStockException.class);
+    }
+
+    @Test
+    void 注文確定_同一商品が複数行あり合計数量が在庫内の場合に正常終了する() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 10L, "O");
+        when(productRepository.findByIds(any())).thenReturn(List.of(product));
+        when(sequenceRepository.getNextValue(eq("order_id"), eq(1L))).thenReturn(100L);
+        when(sequenceRepository.getNextValue(eq("detail_id"), eq(1L))).thenReturn(200L);
+        doNothing().when(orderRepository).saveOrder(any(OrderTransactionParam.class));
+
+        List<OrderConfirmedRequest.Product> products = List.of(
+                createRequestProduct(1L, 3L),
+                createRequestProduct(1L, 3L)
+        );
+
+        ordersService.confirmed(1L, products);
+
+        verify(orderRepository).saveOrder(any(OrderTransactionParam.class));
+    }
+
+    @Test
+    void 注文確定_トランザクション競合時にOutOfStockExceptionがスローされる() {
+        Product product = createProduct(1L, "商品A", 10001L, 1000L, 10L, "O");
+        when(productRepository.findByIds(any())).thenReturn(List.of(product));
+        when(sequenceRepository.getNextValue(eq("order_id"), eq(1L))).thenReturn(100L);
+        when(sequenceRepository.getNextValue(eq("detail_id"), eq(1L))).thenReturn(200L);
+        doThrow(new StockConditionException("stock condition not met", new RuntimeException()))
+                .when(orderRepository).saveOrder(any(OrderTransactionParam.class));
+
+        List<OrderConfirmedRequest.Product> products = List.of(createRequestProduct(1L, 2L));
+
+        assertThatThrownBy(() -> ordersService.confirmed(1L, products))
+                .isInstanceOf(OutOfStockException.class);
+    }
+
+    private Product createProduct(Long productId, String name, Long shopId, Long price, Long stock, String status) {
+        Product product = new Product();
+        product.setProductId(productId);
+        product.setProductName(name);
+        product.setShopId(shopId);
+        product.setPrice(price);
+        product.setStock(stock);
+        product.setStatus(status);
+        return product;
+    }
+
+    private OrderConfirmedRequest.Product createRequestProduct(Long productId, Long quantity) {
+        OrderConfirmedRequest.Product product = new OrderConfirmedRequest.Product();
+        product.setProduct_id(productId);
+        product.setQuantity(quantity);
+        return product;
     }
 }


### PR DESCRIPTION
## 概要
以下の設計書にあわせて、注文確定APIを実装する
https://github.com/ecapp0226/documents/tree/feature/ph1/abydos/api/%E6%B3%A8%E6%96%87%E5%B1%A5%E6%AD%B4%E4%B8%80%E8%A6%A7API

## ここまで確認済み
- JUnitで確認可能なものはテストコードを作成、確認済み
- ローカル上で注文確定API打鍵後、注文一覧APIに反映されることを確認済み
- ローカル上でamazonqによるレビューで問題ないことは確認済み