### PR TITLE
[develop_ph1]フロント向けにログイン・ポート関連の調整

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/common/src/main/java/com/project/abydos/saki/common/config/CookieProperties.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/CookieProperties.java
@@ -1,0 +1,15 @@
+package com.project.abydos.saki.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "security.cookie")
+public class CookieProperties {
+    private boolean secure = true;
+    private String sameSite = "Strict";
+}

--- a/common/src/main/java/com/project/abydos/saki/common/config/CorsConfig.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/CorsConfig.java
@@ -1,0 +1,31 @@
+package com.project.abydos.saki.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+/**
+ * ローカル環境用CORS設定.
+ */
+@Configuration
+@Profile("local")
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        var config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("*"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/common/src/main/java/com/project/abydos/saki/common/config/JwtAuthenticationFilter.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import com.project.abydos.saki.common.util.JwtDecoder;
 import com.project.abydos.saki.common.util.JwtToPrincipalConverter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -49,17 +51,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * リクエストのAuthorizationヘッダーからBearerトークンを抽出する.
+     * リクエストからトークンを抽出する.
+     * Cookieの"token"を優先し、存在しない場合はAuthorizationヘッダーから取得する。
      *
      * @param request HTTPリクエスト
-     * @return トークン文字列（Bearer プレフィックス除去済み）。ヘッダーが存在しない場合は空
+     * @return トークン文字列。存在しない場合は空
      */
     private Optional<String> extractTokenFromRequest(HttpServletRequest request) {
-        String token = request.getHeader(SecurityConstant.AUTHORIZATION_HEADER);
+        Optional<String> cookieToken = extractTokenFromCookie(request);
+        if (cookieToken.isPresent()) {
+            return cookieToken;
+        }
 
-        if (StringUtils.hasText(token) && token.startsWith(SecurityConstant.BEARER_PREFIX)) {
-            return Optional.of(token.substring(SecurityConstant.BEARER_PREFIX_LENGTH));
+        String header = request.getHeader(SecurityConstant.AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(header) && header.startsWith(SecurityConstant.BEARER_PREFIX)) {
+            return Optional.of(header.substring(SecurityConstant.BEARER_PREFIX_LENGTH));
         }
         return Optional.empty();
+    }
+
+    private Optional<String> extractTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(c -> SecurityConstant.TOKEN_COOKIE_NAME.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
     }
 }

--- a/common/src/main/java/com/project/abydos/saki/common/config/SecurityConfiguration.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/SecurityConfiguration.java
@@ -14,6 +14,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Optional;
 
 /**
  * Spring Security設定クラス.
@@ -28,6 +31,8 @@ public class SecurityConfiguration {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     private final CustomUserDetailService customUserDetailService;
+
+    private final Optional<CorsConfigurationSource> corsConfigurationSource;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -45,9 +50,9 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain applicationSecurity(HttpSecurity http) throws Exception {
 
-        http.addFilterBefore(jwtAuthenticationFilter, org.springframework.web.filter.CorsFilter.class);
-
-        http.cors(AbstractHttpConfigurer::disable)
+        http.cors(cors -> corsConfigurationSource
+                        .ifPresentOrElse(cors::configurationSource, cors::disable))
+                .addFilterBefore(jwtAuthenticationFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -57,6 +62,7 @@ public class SecurityConfiguration {
                                 .requestMatchers(Endpoint.ROOT).permitAll()
                                 .requestMatchers(Endpoint.HEALTH).permitAll()
                                 .requestMatchers(Endpoint.API_PREFIX + Endpoint.LOGIN).permitAll()
+                                .requestMatchers(Endpoint.API_PREFIX + "/me").permitAll()
                                 .requestMatchers(Endpoint.API_PREFIX + Endpoint.PRODUCTS + "/**").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/common/src/main/java/com/project/abydos/saki/common/constant/SecurityConstant.java
+++ b/common/src/main/java/com/project/abydos/saki/common/constant/SecurityConstant.java
@@ -23,8 +23,14 @@ public class SecurityConstant {
     /** JWT claim: ユーザーID */
     public static final String CLAIM_USER_ID = "user_id";
 
+    /** JWT claim: ユーザー名 */
+    public static final String CLAIM_USER_NAME = "n";
+
     /** JWTの有効期限（時間） */
     public static final long TOKEN_EXPIRATION_HOURS = 1;
+
+    /** Cookie名: トークン */
+    public static final String TOKEN_COOKIE_NAME = "token";
 
     private SecurityConstant() {}
 }

--- a/common/src/main/java/com/project/abydos/saki/common/entity/UserPrincipal.java
+++ b/common/src/main/java/com/project/abydos/saki/common/entity/UserPrincipal.java
@@ -19,6 +19,9 @@ public class UserPrincipal implements UserDetails {
     /** ユーザーID */
     private final Long userId;
 
+    /** ユーザー名 */
+    private final String userName;
+
     /** メールアドレス */
     private final String email;
 
@@ -42,6 +45,10 @@ public class UserPrincipal implements UserDetails {
     @Override
     public String getUsername() {
         return email;
+    }
+
+    public String getUserName() {
+        return userName;
     }
 
     @Override

--- a/common/src/main/java/com/project/abydos/saki/common/util/JwtToPrincipalConverter.java
+++ b/common/src/main/java/com/project/abydos/saki/common/util/JwtToPrincipalConverter.java
@@ -27,6 +27,7 @@ public class JwtToPrincipalConverter {
     public static UserPrincipal convert(@NonNull DecodedJWT jwt) {
         return UserPrincipal.builder()
                 .userId(Long.valueOf(jwt.getSubject()))
+                .userName(jwt.getClaim(SecurityConstant.CLAIM_USER_NAME).asString())
                 .email(jwt.getClaim(SecurityConstant.CLAIM_EMAIL).asString())
                 .authorities(extractAuthorities(jwt))
                 .build();

--- a/common/src/main/resources/application-common-local.yaml
+++ b/common/src/main/resources/application-common-local.yaml
@@ -1,3 +1,6 @@
 security:
   jwt:
     secret: local-dev-secret-key-for-testing-only
+  cookie:
+    secure: false
+    same-site: None

--- a/orders/src/docker/Dockerfile
+++ b/orders/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM amazoncorretto:17-alpine
 WORKDIR /app
 COPY build/libs/orders.jar orders.jar
 EXPOSE 8080

--- a/orders/src/docker/Dockerfile
+++ b/orders/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine
+FROM public.ecr.aws/docker/library/amazoncorretto:17-alpine
 WORKDIR /app
 COPY build/libs/orders.jar orders.jar
 EXPOSE 8080

--- a/orders/src/main/resources/application-local.yaml
+++ b/orders/src/main/resources/application-local.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 8082
+
 spring:
   docker:
     compose:

--- a/products/src/docker/Dockerfile
+++ b/products/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM amazoncorretto:17-alpine
 WORKDIR /app
 COPY build/libs/products.jar products.jar
 EXPOSE 8080

--- a/products/src/docker/Dockerfile
+++ b/products/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine
+FROM public.ecr.aws/docker/library/amazoncorretto:17-alpine
 WORKDIR /app
 COPY build/libs/products.jar products.jar
 EXPOSE 8080

--- a/products/src/main/resources/application-local.yaml
+++ b/products/src/main/resources/application-local.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 8081
+
 spring:
   docker:
     compose:

--- a/users/src/docker/Dockerfile
+++ b/users/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-alpine
+FROM public.ecr.aws/docker/library/amazoncorretto:17-alpine
 WORKDIR /app
 COPY build/libs/users.jar users.jar
 EXPOSE 8080

--- a/users/src/docker/Dockerfile
+++ b/users/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM amazoncorretto:17-alpine
 WORKDIR /app
 COPY build/libs/users.jar users.jar
 EXPOSE 8080

--- a/users/src/main/java/com/project/abydos/saki/api/users/constant/UsersEndpoint.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/constant/UsersEndpoint.java
@@ -6,6 +6,8 @@ package com.project.abydos.saki.api.users.constant;
 public class UsersEndpoint {
     /** ログイン */
     public static final String LOGIN = "/login";
+    /** ユーザー情報取得 */
+    public static final String ME = "/me";
 
     private UsersEndpoint() {}
 }

--- a/users/src/main/java/com/project/abydos/saki/api/users/controller/LoginController.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/controller/LoginController.java
@@ -4,6 +4,7 @@ import com.project.abydos.saki.api.users.request.LoginRequest;
 import com.project.abydos.saki.api.users.response.LoginResponse;
 import com.project.abydos.saki.api.users.facade.LoginFacade;
 import com.project.abydos.saki.api.users.constant.UsersEndpoint;
+import com.project.abydos.saki.common.config.CookieProperties;
 import com.project.abydos.saki.common.constant.Endpoint;
 import com.project.abydos.saki.common.constant.SecurityConstant;
 import jakarta.validation.Valid;
@@ -27,6 +28,8 @@ public class LoginController {
 
     private final LoginFacade loginFacade;
 
+    private final CookieProperties cookieProperties;
+
     /**
      * ログイン処理を実行する.
      *
@@ -39,8 +42,8 @@ public class LoginController {
 
         ResponseCookie cookie = ResponseCookie.from(SecurityConstant.TOKEN_COOKIE_NAME, response.getToken())
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .secure(cookieProperties.isSecure())
+                .sameSite(cookieProperties.getSameSite())
                 .path("/")
                 .maxAge(SecurityConstant.TOKEN_EXPIRATION_HOURS * 3600)
                 .build();

--- a/users/src/main/java/com/project/abydos/saki/api/users/controller/LoginController.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/controller/LoginController.java
@@ -5,8 +5,11 @@ import com.project.abydos.saki.api.users.response.LoginResponse;
 import com.project.abydos.saki.api.users.facade.LoginFacade;
 import com.project.abydos.saki.api.users.constant.UsersEndpoint;
 import com.project.abydos.saki.common.constant.Endpoint;
+import com.project.abydos.saki.common.constant.SecurityConstant;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,10 +31,22 @@ public class LoginController {
      * ログイン処理を実行する.
      *
      * @param request メールアドレスとパスワードを含むリクエスト
-     * @return JWTトークンとユーザー名を含むレスポンス
+     * @return ユーザー名を含むレスポンス（トークンはSet-Cookieヘッダーで返却）
      */
     @PostMapping(UsersEndpoint.LOGIN)
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(loginFacade.login(request));
+        LoginResponse response = loginFacade.login(request);
+
+        ResponseCookie cookie = ResponseCookie.from(SecurityConstant.TOKEN_COOKIE_NAME, response.getToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(SecurityConstant.TOKEN_EXPIRATION_HOURS * 3600)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(response);
     }
 }

--- a/users/src/main/java/com/project/abydos/saki/api/users/controller/UserInfoController.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/controller/UserInfoController.java
@@ -4,8 +4,10 @@ import com.project.abydos.saki.api.users.constant.UsersEndpoint;
 import com.project.abydos.saki.api.users.facade.UserInfoFacade;
 import com.project.abydos.saki.api.users.response.UserInfoResponse;
 import com.project.abydos.saki.common.constant.Endpoint;
+import com.project.abydos.saki.common.entity.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +30,9 @@ public class UserInfoController {
      */
     @GetMapping(UsersEndpoint.ME)
     public ResponseEntity<UserInfoResponse> getUserInfo() {
+        if (!(SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof UserPrincipal)) {
+            return ResponseEntity.noContent().build();
+        }
         return ResponseEntity.ok(userInfoFacade.getUserInfo());
     }
 }

--- a/users/src/main/java/com/project/abydos/saki/api/users/controller/UserInfoController.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/controller/UserInfoController.java
@@ -1,0 +1,33 @@
+package com.project.abydos.saki.api.users.controller;
+
+import com.project.abydos.saki.api.users.constant.UsersEndpoint;
+import com.project.abydos.saki.api.users.facade.UserInfoFacade;
+import com.project.abydos.saki.api.users.response.UserInfoResponse;
+import com.project.abydos.saki.common.constant.Endpoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * ユーザー情報取得APIのController.
+ * GET /api/v1/me エンドポイントを提供する。
+ */
+@RestController
+@RequestMapping(Endpoint.API_PREFIX)
+@RequiredArgsConstructor
+public class UserInfoController {
+
+    private final UserInfoFacade userInfoFacade;
+
+    /**
+     * 認証済みユーザーの情報を取得する.
+     *
+     * @return ユーザー情報レスポンス（userId, userName, email）
+     */
+    @GetMapping(UsersEndpoint.ME)
+    public ResponseEntity<UserInfoResponse> getUserInfo() {
+        return ResponseEntity.ok(userInfoFacade.getUserInfo());
+    }
+}

--- a/users/src/main/java/com/project/abydos/saki/api/users/facade/UserInfoFacade.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/facade/UserInfoFacade.java
@@ -1,0 +1,30 @@
+package com.project.abydos.saki.api.users.facade;
+
+import com.project.abydos.saki.api.users.response.UserInfoResponse;
+import com.project.abydos.saki.api.users.service.UserInfoService;
+import com.project.abydos.saki.common.entity.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * ユーザー情報取得APIのFacade.
+ * SecurityContextからUserPrincipalを取得し、Serviceへ処理を委譲する。
+ */
+@Component
+@RequiredArgsConstructor
+public class UserInfoFacade {
+
+    private final UserInfoService userInfoService;
+
+    /**
+     * 認証済みユーザーの情報を取得する.
+     *
+     * @return ユーザー情報レスポンス
+     */
+    public UserInfoResponse getUserInfo() {
+        UserPrincipal principal = (UserPrincipal) SecurityContextHolder.getContext()
+                .getAuthentication().getPrincipal();
+        return userInfoService.getUserInfo(principal);
+    }
+}

--- a/users/src/main/java/com/project/abydos/saki/api/users/response/UserInfoResponse.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/response/UserInfoResponse.java
@@ -1,23 +1,24 @@
 package com.project.abydos.saki.api.users.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
- * ログインAPIレスポンス.
+ * ユーザー情報取得APIレスポンス.
  */
 @Data
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class LoginResponse {
+public class UserInfoResponse {
 
-    /** JWTトークン（Cookieで返却するためレスポンスボディには含めない） */
-    @JsonIgnore
-    private String token;
+    /** ユーザーID */
+    private Long userId;
 
-    /** ユーザー表示名 */
+    /** ユーザー名 */
     private String userName;
+
+    /** メールアドレス */
+    private String email;
 }

--- a/users/src/main/java/com/project/abydos/saki/api/users/service/LoginService.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/service/LoginService.java
@@ -54,6 +54,7 @@ public class LoginService {
                 .withSubject(user.getUserId().toString())
                 .withClaim(SecurityConstant.CLAIM_USER_ID, user.getUserId())
                 .withClaim(SecurityConstant.CLAIM_EMAIL, user.getEmail())
+                .withClaim(SecurityConstant.CLAIM_USER_NAME, user.getUserName())
                 .withExpiresAt(Instant.now().plus(SecurityConstant.TOKEN_EXPIRATION_HOURS, ChronoUnit.HOURS))
                 .sign(Algorithm.HMAC256(jwtProperties.getSecret()));
 

--- a/users/src/main/java/com/project/abydos/saki/api/users/service/UserInfoService.java
+++ b/users/src/main/java/com/project/abydos/saki/api/users/service/UserInfoService.java
@@ -1,0 +1,23 @@
+package com.project.abydos.saki.api.users.service;
+
+import com.project.abydos.saki.api.users.response.UserInfoResponse;
+import com.project.abydos.saki.common.entity.UserPrincipal;
+import org.springframework.stereotype.Service;
+
+/**
+ * ユーザー情報取得サービス.
+ * JWTのclaimsから取得済みのUserPrincipalを元にレスポンスを生成する。
+ */
+@Service
+public class UserInfoService {
+
+    /**
+     * UserPrincipalからユーザー情報レスポンスを生成する.
+     *
+     * @param principal 認証済みユーザー情報
+     * @return ユーザー情報レスポンス
+     */
+    public UserInfoResponse getUserInfo(UserPrincipal principal) {
+        return new UserInfoResponse(principal.getUserId(), principal.getUserName(), principal.getEmail());
+    }
+}

--- a/users/src/test/java/com/project/abydos/saki/api/users/controller/LoginControllerTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/controller/LoginControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,7 +45,7 @@ class LoginControllerTest {
     }
 
     @Test
-    void ログイン成功時にトークンとユーザー名が返却される() throws Exception {
+    void ログイン成功時にCookieにトークンが設定されユーザー名が返却される() throws Exception {
         LoginResponse response = new LoginResponse("test-token", "テストユーザー");
         when(loginFacade.login(any(LoginRequest.class))).thenReturn(response);
 
@@ -56,7 +57,12 @@ class LoginControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.token").value("test-token"))
+                .andExpect(cookie().value("token", "test-token"))
+                .andExpect(cookie().httpOnly("token", true))
+                .andExpect(cookie().secure("token", true))
+                .andExpect(cookie().path("token", "/"))
+                .andExpect(cookie().maxAge("token", 3600))
+                .andExpect(jsonPath("$.token").doesNotExist())
                 .andExpect(jsonPath("$.user_name").value("テストユーザー"));
     }
 

--- a/users/src/test/java/com/project/abydos/saki/api/users/controller/UserInfoControllerTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/controller/UserInfoControllerTest.java
@@ -1,0 +1,48 @@
+package com.project.abydos.saki.api.users.controller;
+
+import com.project.abydos.saki.api.users.constant.UsersEndpoint;
+import com.project.abydos.saki.api.users.facade.UserInfoFacade;
+import com.project.abydos.saki.api.users.response.UserInfoResponse;
+import com.project.abydos.saki.common.constant.Endpoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+class UserInfoControllerTest {
+
+    private MockMvc mockMvc;
+
+    @InjectMocks
+    private UserInfoController userInfoController;
+
+    @Mock
+    private UserInfoFacade userInfoFacade;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userInfoController).build();
+    }
+
+    @Test
+    void ユーザー情報取得成功時にユーザー情報が返却される() throws Exception {
+        UserInfoResponse response = new UserInfoResponse(1L, "テストユーザー", "test@example.com");
+        when(userInfoFacade.getUserInfo()).thenReturn(response);
+
+        mockMvc.perform(get(Endpoint.API_PREFIX + UsersEndpoint.ME))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user_id").value(1))
+                .andExpect(jsonPath("$.user_name").value("テストユーザー"))
+                .andExpect(jsonPath("$.email").value("test@example.com"));
+    }
+}

--- a/users/src/test/java/com/project/abydos/saki/api/users/facade/UserInfoFacadeTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/facade/UserInfoFacadeTest.java
@@ -1,0 +1,60 @@
+package com.project.abydos.saki.api.users.facade;
+
+import com.project.abydos.saki.api.users.response.UserInfoResponse;
+import com.project.abydos.saki.api.users.service.UserInfoService;
+import com.project.abydos.saki.common.entity.UserPrincipal;
+import com.project.abydos.saki.common.entity.UserPrincipalAuthenticationToken;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserInfoFacadeTest {
+
+    @Mock
+    private UserInfoService userInfoService;
+
+    @InjectMocks
+    private UserInfoFacade userInfoFacade;
+
+    private UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        principal = UserPrincipal.builder()
+                .userId(1L)
+                .userName("テストユーザー")
+                .email("test@example.com")
+                .authorities(List.of())
+                .build();
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UserPrincipalAuthenticationToken(principal));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void SecurityContextからユーザー情報を取得しServiceに委譲する() {
+        UserInfoResponse expected = new UserInfoResponse(1L, "テストユーザー", "test@example.com");
+        when(userInfoService.getUserInfo(principal)).thenReturn(expected);
+
+        UserInfoResponse result = userInfoFacade.getUserInfo();
+
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getUserName()).isEqualTo("テストユーザー");
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+    }
+}

--- a/users/src/test/java/com/project/abydos/saki/api/users/service/UserInfoServiceTest.java
+++ b/users/src/test/java/com/project/abydos/saki/api/users/service/UserInfoServiceTest.java
@@ -1,0 +1,35 @@
+package com.project.abydos.saki.api.users.service;
+
+import com.project.abydos.saki.api.users.response.UserInfoResponse;
+import com.project.abydos.saki.common.entity.UserPrincipal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class UserInfoServiceTest {
+
+    @InjectMocks
+    private UserInfoService userInfoService;
+
+    @Test
+    void UserPrincipalからユーザー情報レスポンスが生成される() {
+        UserPrincipal principal = UserPrincipal.builder()
+                .userId(1L)
+                .userName("テストユーザー")
+                .email("test@example.com")
+                .authorities(List.of())
+                .build();
+
+        UserInfoResponse result = userInfoService.getUserInfo(principal);
+
+        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getUserName()).isEqualTo("テストユーザー");
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+    }
+}


### PR DESCRIPTION
## 概要
フロント側の状況を確認したところ、以下の課題があり対応

- セキュリティ面でlocalStorageではなくCookieを使いたい
- 一方でローカル環境はドメインが異なるのでそれは許容したい
- Cookieからトークンを取り出せないため、バックエンド側でトークンを取り出しユーザー情報を返すAPIが必要

## 対応
