### PR TITLE
[feature/develop_ph1 -> develop_ph1]受注に紐づく明細が指定した順番で返されず、NGになるため修正

### DIFF
--- a/orders/src/main/java/com/project/abydos/saki/api/orders/service/OrdersService.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/service/OrdersService.java
@@ -64,7 +64,9 @@ public class OrdersService {
         Map<Long, List<OrderDetail>> detailsByOrderId = Collections.emptyMap();
         if (!orderDetailIdsMap.isEmpty()) {
             List<OrderDetail> details = orderDetailRepository.batchGetByOrderDetailIds(orderDetailIdsMap);
+
             detailsByOrderId = details.stream()
+                    .sorted(Comparator.comparing(OrderDetail::getDetailId))
                     .collect(Collectors.groupingBy(OrderDetail::getOrderId));
         }
 

--- a/orders/src/test/java/com/project/abydos/saki/api/orders/service/OrdersServiceTest.java
+++ b/orders/src/test/java/com/project/abydos/saki/api/orders/service/OrdersServiceTest.java
@@ -133,6 +133,29 @@ class OrdersServiceTest {
     }
 
     @Test
+    void order_detailsがdetailIdの昇順でソートされて返却される() {
+        Order order = createOrder(1L, 1001L, 1700000100000L, Set.of(1L, 2L, 3L));
+
+        // detailIdが逆順で返却されるケース
+        OrderDetail detail1 = createOrderDetail(1001L, 3L, 10001L, 1L, "商品C", 500L, 1L, "ED");
+        OrderDetail detail2 = createOrderDetail(1001L, 1L, 10002L, 2L, "商品A", 1000L, 1L, "ED");
+        OrderDetail detail3 = createOrderDetail(1001L, 2L, 10003L, 3L, "商品B", 2000L, 1L, "ED");
+
+        when(orderRepository.findByUserId(1L, 10, null))
+                .thenReturn(new PagedResult<>(List.of(order), null));
+        when(orderDetailRepository.batchGetByOrderDetailIds(any()))
+                .thenReturn(List.of(detail1, detail2, detail3));
+
+        OrdersApiResponse response = ordersService.getOrders(1L, 10, null);
+
+        List<OrdersApiResponse.DetailResponse> details = response.getOrders().get(0).getDetails();
+        assertThat(details).hasSize(3);
+        assertThat(details.get(0).getDetailId()).isEqualTo(1L);
+        assertThat(details.get(1).getDetailId()).isEqualTo(2L);
+        assertThat(details.get(2).getDetailId()).isEqualTo(3L);
+    }
+
+    @Test
     void order_detailのtotalがprice_orderNumで計算される() {
         Order order = createOrder(1L, 1001L, 1700000100000L, Set.of(1L));
         OrderDetail detail = createOrderDetail(1001L, 1L, 10001L, 1L, "商品A", 1500L, 3L, "ED");


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1U8LuS5Qw6_GA7p6Q9w8P7n4iDmBi8gl7k-igkrwpITM/edit?gid=135829656#gid=135829656

上記試験項目001のNGの修正
受注は降順で返されるが、明細が昇順でなく、たたく度に順序が変わる
BatchGetItem上の仕様のため、受け取った後でアプリ側で昇順でソートをかける