### PR TITLE
[feature/develop_ph1 -> develop_ph1]トランザクション管理の上限数の制約について認識違いがあるため、バックエンドも画面仕様の上限に合わせる

### DIFF
--- a/orders/src/main/java/com/project/abydos/saki/api/orders/request/OrderConfirmedRequest.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/request/OrderConfirmedRequest.java
@@ -21,7 +21,7 @@ public class OrderConfirmedRequest {
 
     /** 商品リスト */
     @Valid
-    @Size(min = 1, max = 100)
+    @Size(min = 1, max = 20)
     @NotEmpty
     private List<Product> products;
 

--- a/orders/src/test/java/com/project/abydos/saki/api/orders/controller/OrdersControllerTest.java
+++ b/orders/src/test/java/com/project/abydos/saki/api/orders/controller/OrdersControllerTest.java
@@ -289,4 +289,23 @@ class OrdersControllerTest {
                         .content(new ObjectMapper().writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void 注文確定_商品リストが20件の場合200_OKが返るか() throws Exception {
+        List<OrderConfirmedRequest.Product> products = java.util.stream.IntStream.rangeClosed(1, 20)
+                .mapToObj(i -> {
+                    OrderConfirmedRequest.Product p = new OrderConfirmedRequest.Product();
+                    p.setProduct_id((long) i);
+                    p.setQuantity(1L);
+                    return p;
+                }).toList();
+
+        OrderConfirmedRequest request = new OrderConfirmedRequest();
+        request.setProducts(products);
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
 }

--- a/orders/src/test/java/com/project/abydos/saki/api/orders/controller/OrdersControllerTest.java
+++ b/orders/src/test/java/com/project/abydos/saki/api/orders/controller/OrdersControllerTest.java
@@ -272,8 +272,8 @@ class OrdersControllerTest {
     }
 
     @Test
-    void 注文確定_商品リストが101件の場合バリデーションエラー() throws Exception {
-        List<OrderConfirmedRequest.Product> products = java.util.stream.IntStream.rangeClosed(1, 101)
+    void 注文確定_商品リストが21件の場合バリデーションエラー() throws Exception {
+        List<OrderConfirmedRequest.Product> products = java.util.stream.IntStream.rangeClosed(1, 21)
                 .mapToObj(i -> {
                     OrderConfirmedRequest.Product p = new OrderConfirmedRequest.Product();
                     p.setProduct_id((long) i);


### PR DESCRIPTION
https://github.com/ecapp0226/documents/pull/19
上記プルリクエストの対応を実施