### PR TITLE
[feature/develop_ph1 -> develop_ph1]リクエストボディ関連の不正時、バリデーションチェックが発火しないため、共通ハンドラーの追加

### DIFF
--- a/common/src/main/java/com/project/abydos/saki/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/project/abydos/saki/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.project.abydos.saki.common.constant.ErrorCode;
 import com.project.abydos.saki.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -91,6 +92,19 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        ErrorCode code = ErrorCode.API_ERR001;
+        log.warn(CommonErrorLogMessage.VALIDATION_ERROR.getMessage(), ex.getMessage(), ex);
+        return new ResponseEntity<>(
+                new ErrorResponse(code.name(), code.getMessage()),
+                code.getHttpStatus()
+        );
+    }
+
+    /**
+     * リクエストボディの読み取り失敗ハンドラー.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
         ErrorCode code = ErrorCode.API_ERR001;
         log.warn(CommonErrorLogMessage.VALIDATION_ERROR.getMessage(), ex.getMessage(), ex);
         return new ResponseEntity<>(

--- a/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
+++ b/orders/src/main/java/com/project/abydos/saki/api/orders/controller/OrdersController.java
@@ -8,6 +8,7 @@ import com.project.abydos.saki.common.constant.Endpoint;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -38,7 +39,8 @@ public class OrdersController {
      * @return 成功時は200 OK
      */
     @PostMapping(Endpoint.ORDERS)
-    public ResponseEntity<Void> postOrders(@Valid @RequestBody OrderConfirmedRequest orderConfirmedRequest) {
+    public ResponseEntity<Void> postOrders(
+            @Validated @RequestBody OrderConfirmedRequest orderConfirmedRequest) {
 
         ordersFacade.confirmed(orderConfirmedRequest);
 


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1w8M2l6hJxIimXOxO1GC2p_TF5NiXERsZmZFXlAJeImM/edit?gid=135829656#gid=135829656

上記のNG事項
リクエストボディの中身が空やパースエラー、型の不整合時に400にならず、500エラーになる

## 対応
- HttpMessageNotReadableExceptionでのハンドリングの追加