### PR TITLE
[feature/develop_ph1 -> develop_ph1]小数点をリクエストボディに入れると整数に切り捨ててリクエストが通るため修正

### DIFF
--- a/common/src/main/java/com/project/abydos/saki/common/config/JacksonConfig.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/JacksonConfig.java
@@ -19,9 +19,7 @@ public class JacksonConfig {
      */
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer customizer() {
-        return builder -> builder.featuresToEnable(
-                DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES
-        ).featuresToDisable(
+        return builder -> builder.featuresToDisable(
                 DeserializationFeature.ACCEPT_FLOAT_AS_INT
         );
     }

--- a/common/src/main/java/com/project/abydos/saki/common/config/JacksonConfig.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/JacksonConfig.java
@@ -1,0 +1,28 @@
+package com.project.abydos.saki.common.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Jackson関連の設定のBean定義
+ */
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * Jacksonのカスタマイズ
+     * 小数点が渡された際に切り捨てで整数に変換するため、バリデーションエラーになるよう設定を記載する
+     *
+     * @return Jackson2ObjectMapperBuilderCustomizer
+     */
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customizer() {
+        return builder -> builder.featuresToEnable(
+                DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES
+        ).featuresToDisable(
+                DeserializationFeature.ACCEPT_FLOAT_AS_INT
+        );
+    }
+}


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1w8M2l6hJxIimXOxO1GC2p_TF5NiXERsZmZFXlAJeImM/edit?gid=135829656#gid=135829656

上記試験項目No.10でNG
Jacksonの挙動上整数に、切り捨ててしまうため、変換しないよう共通で設定を無効にする