### PR TITLE
[feature/develop_ph1.5 -> develop_ph1.5]logbackのフォーマットを定義する

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ subprojects {
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'org.springframework.boot:spring-boot-starter-validation'
+		implementation 'ch.qos.logback.access:logback-access-tomcat:2.0.6'
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'org.projectlombok:lombok'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/common/src/main/java/com/project/abydos/saki/common/config/LogbackAccessConfig.java
+++ b/common/src/main/java/com/project/abydos/saki/common/config/LogbackAccessConfig.java
@@ -1,0 +1,22 @@
+package com.project.abydos.saki.common.config;
+
+import ch.qos.logback.access.tomcat.LogbackValve;
+import org.springframework.boot.web.embedded.tomcat.ConfigurableTomcatWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * tomcatのアクセスログをカスタムフォーマットで出すためのBean定義
+ */
+@Configuration
+public class LogbackAccessConfig {
+
+    @Bean
+    public WebServerFactoryCustomizer<ConfigurableTomcatWebServerFactory> webServerFactoryCustomizer() {
+        return (factory) -> {
+            LogbackValve v = new LogbackValve();
+            factory.addEngineValves(v);
+        };
+    }
+}

--- a/common/src/main/resources/conf/logback-access.xml
+++ b/common/src/main/resources/conf/logback-access.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%h %l %u [%t{yyyy-MM-dd HH:mm:ss}] [%I] [access] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <appender-ref ref="STDOUT"/>
+</configuration>

--- a/common/src/main/resources/logback-spring.xml
+++ b/common/src/main/resources/logback-spring.xml
@@ -1,0 +1,48 @@
+<configuration>
+    <springProfile name="local">
+        <property name="ROOT_LOG_LEVEL" value="INFO"/>
+        <logger name="com.project.abydos.saki.dynamodb" level="DEBUG"/>
+    </springProfile>
+
+    <springProfile name="dev">
+        <property name="ROOT_LOG_LEVEL" value="INFO"/>
+        <logger name="com.project.abydos.saki.dynamodb" level="WARN"/>
+    </springProfile>
+
+    <appender name="APPLICATION" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [application] [%thread] %level %logger %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="APPLICATION_WARN" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [warn] [%thread] %level %logger %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+    <appender name="APPLICATION_ERROR" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [error] [%thread] %level %logger %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+    <root level="${ROOT_LOG_LEVEL}">
+        <appender-ref ref="APPLICATION"/>
+        <appender-ref ref="APPLICATION_WARN"/>
+        <appender-ref ref="APPLICATION_ERROR"/>
+    </root>
+</configuration>


### PR DESCRIPTION
https://github.com/sunaba0226/documents/blob/feature/ph1.5/docs/projects/develop_ph1.5/develop_ph1.5.md

上記の資料の内容をもとに、以下の対応を実施する
- アプリケーション毎のログ、ERROR、WARNレベルでのログを定義の形でフォーマットするように設定を定義する
- tomcatのアクセスログをカスタムのフォーマットで出力するようにする